### PR TITLE
Coverting builDocs to static for easier usage

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -45,7 +45,7 @@ exports.symbols = {
   SEMICOLON: ';'
 };
 
-exports.DEFAULT_DOCS_DIR = 'docs_open';
+exports.DEFAULT_DOCS_DIR = 'docs';
 exports.DEFAULT_OPEN_API = '3.0.0';
 exports.DEFAULT_TEST_SUIT = 'supertest';
 

--- a/lib/silk_paper.js
+++ b/lib/silk_paper.js
@@ -55,7 +55,7 @@ module.exports = class SilkPaper {
    *
    * @return {void}
    */
-  static genDocs(response, options) {
+  static genDocs(response, options = {}) {
     generateSpec(response, {
       description: options.description,
       paths: [options.path],

--- a/lib/silk_paper.js
+++ b/lib/silk_paper.js
@@ -66,11 +66,17 @@ module.exports = class SilkPaper {
   /**
    * buildDocs.
    *
-   * Function to generate documentation (OpenApi specification) object.
+   * Function to generate documentation (OpenApi specification) object to UI server
    *
-   * @return {Object} - OpenApi Specification object.
+   * @param {Objects} options - Configuration object
+   * @param {Objects} options.docsDir  -  Path to the folder in which the documentation is stored
+   * @param {Objects} options.fileType  - File type of stored the documentation.
+   *
+   * @return {Object} - OpenApi Specification object
    */
-  buildDocs() {
-    return buildSpecObject(this);
+  static buildDocs(options = {}) {
+    const docsDir = options.docsDir || DEFAULT_DOCS_DIR;
+    const fileType = options.fileType ? options.fileType : fileTypes.JSON;
+    return buildSpecObject({ docsDir, fileType });
   }
 };

--- a/lib/silk_paper.js
+++ b/lib/silk_paper.js
@@ -14,8 +14,8 @@ module.exports = class SilkPaper {
    *
    * @param {Object} server - A rest server instance, from which to obtain intial information about the API.
    * @param {Objects} options - Configuration Object.
-   * @param {Objects} options.docsDir  -  Path to the folder in which the documentation is stored.
-   * @param {Objects} options.fileType  - Desired file type to stored the documentation.
+   * @param {String} options.docsDir  -  Path to the folder in which the documentation is stored.
+   * @param {String} options.fileType  - Desired file type to stored the documentation.
    */
   constructor(server, options = {}) {
     this.docsDir = options.docsDir || DEFAULT_DOCS_DIR;
@@ -34,7 +34,7 @@ module.exports = class SilkPaper {
    *s
    * @param {Object} response - An HTTP response object.
    * @param {Objects} options - Configuration object.
-   * @param {Objects} options.description - Description for the endpoint response.
+   * @param {String} options.description - Description for the endpoint response.
    *
    * @return {void}
    */
@@ -49,9 +49,9 @@ module.exports = class SilkPaper {
    *
    * @param {Object} response - An HTTP response object.
    * @param {Objects} options - Configuration object.
-   * @param {Objects} options.description - Description for the endpoint response.
-   * @param {Objects} options.docsDir  -  Path to the folder in which the documentation is stored.
-   * @param {Objects} options.path - REST API path that is being documented.
+   * @param {String} options.description - Description for the endpoint response.
+   * @param {String} options.docsDir  -  Path to the folder in which the documentation is stored.
+   * @param {String} options.path - REST API path that is being documented.
    *
    * @return {void}
    */
@@ -69,10 +69,10 @@ module.exports = class SilkPaper {
    * Function to generate documentation (OpenApi specification) object to UI server
    *
    * @param {Objects} options - Configuration object
-   * @param {Objects} options.docsDir  -  Path to the folder in which the documentation is stored
-   * @param {Objects} options.fileType  - File type of stored the documentation.
+   * @param {String} options.docsDir  -  Path to the folder in which the documentation is stored
+   * @param {String} options.fileType  - File type of stored the documentation.
    *
-   * @return {Object} - OpenApi Specification object
+   * @return {Object} OpenApi Specification object
    */
   static buildDocs(options = {}) {
     const docsDir = options.docsDir || DEFAULT_DOCS_DIR;


### PR DESCRIPTION
## Summary
 - Converted `buildDocs` method to static to be used independently from the app class
 - Fixed js docs
 - Changed default docs directory